### PR TITLE
feat: add CFX/USDT (6 digits) example

### DIFF
--- a/contracts/CfxUsdtPriceFeed.sol
+++ b/contracts/CfxUsdtPriceFeed.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+
+// Import the UsingWitnet library that enables interacting with Witnet
+import "witnet-ethereum-bridge/contracts/UsingWitnet.sol";
+// Import the ERC2362 interface
+import "adomedianizer/contracts/interfaces/IERC2362.sol";
+// Import the CFX-USDT-6 request that you created before
+import "./requests/CfxUsdt6.sol";
+
+// Your contract needs to inherit from UsingWitnet
+contract CfxUsdtPriceFeed is UsingWitnet, IERC2362 {
+
+    using Witnet for Witnet.Result;
+
+    // The public CFX/USDT price point
+    uint64 public lastPrice;
+
+    // Stores the ID of the last Witnet request
+    uint256 public lastRequestId;
+
+    // Stores the timestamp of the last time the public price point was updated
+    uint256 public timestamp;
+
+    // Tells if an update has been requested but not yet completed
+    bool public pending;
+
+    // The Witnet request object, is set in the constructor
+    Request public request;
+
+    // Emits when the price is updated
+    event PriceUpdated(uint64);
+
+    // Emits when found an error decoding request result
+    event ResultError(string);
+
+    // This is `keccak256("Price-CFX/USDT-6")`
+    bytes32 constant public CFXUSDT6ID = bytes32(hex"65784185a07d3add5e7a99a6ddd4477e3c8caad717bac3ba3c3361d99a978c29");
+
+    // This constructor does a nifty trick to tell the `UsingWitnet` library where
+    // to find the Witnet contracts on whatever Ethereum network you use.
+    constructor (address _wrb) UsingWitnet(_wrb) {
+        // Instantiate the Witnet request
+        request = new CfxUsdt6Request();
+    }
+
+    /**
+    * @notice Sends `request` to the WitnetRequestBoard.
+    * @dev This method will only succeed if `pending` is 0.
+    **/
+    function requestUpdate() public payable {
+        require(!pending, "Complete pending request before requesting a new one");
+
+        // Send the request to Witnet and store the ID for later retrieval of the result
+        // The `witnetPostRequest` method comes with `UsingWitnet`
+        lastRequestId = witnetPostRequest(request);
+
+        // Signal that there is already a pending request
+        pending = true;
+    }
+
+    /**
+    * @notice Reads the result, if ready, from the WitnetRequestBoard.
+    * @dev The `witnetRequestAccepted` modifier comes with `UsingWitnet` and allows to
+    * protect your methods from being called before the request has been successfully
+    * relayed into Witnet.
+    **/
+    function completeUpdate() public witnetRequestResolved(lastRequestId) {
+        require(pending, "There is no pending update.");
+
+        // Read the result of the Witnet request
+        // The `witnetReadResult` method comes with `UsingWitnet`
+        Witnet.Result memory result = witnetReadResult(lastRequestId);
+
+        // If the Witnet request succeeded, decode the result and update the price point
+        // If it failed, revert the transaction with a pretty-printed error message
+        if (result.isOk()) {
+            lastPrice = result.asUint64();
+            // solhint-disable-next-line not-rely-on-time
+            timestamp = block.timestamp;
+            emit PriceUpdated(lastPrice);
+        } else {
+            string memory errorMessage;
+
+            // Try to read the value as an error message, catch error bytes if read fails
+            try result.asErrorMessage() returns (Witnet.ErrorCodes, string memory e) {
+                errorMessage = e;
+            }
+            catch (bytes memory errorBytes){
+                errorMessage = string(errorBytes);
+            }
+            emit ResultError(errorMessage);
+        }
+
+        // In any case, set `pending` to false so a new update can be requested
+        pending = false;
+    }
+
+    /**
+    * @notice Exposes the public data point in an ERC2362 compliant way.
+    * @dev Returns error `400` if queried for an unknown data point, and `404` if `completeUpdate` has never been called
+    * successfully before.
+    **/
+    function valueFor(bytes32 _id) external view override returns(int256, uint256, uint256) {
+        // Unsupported data point ID
+        if(_id != CFXUSDT6ID) return(0, 0, 400);
+        // No value is yet available for the queried data point ID
+        if (timestamp == 0) return(0, 0, 404);
+
+        int256 value = int256(uint256(lastPrice));
+
+        return(value, timestamp, 200);
+    }
+}

--- a/requests/CfxUsdt6.js
+++ b/requests/CfxUsdt6.js
@@ -1,0 +1,77 @@
+import * as Witnet from "witnet-requests"
+
+// Retrieves USDT price of CFX from the Binance API
+const binance = new Witnet.Source("https://api.binance.com/api/v3/ticker/price?symbol=CFXUSDT")
+  .parseJSONMap() // Parse a `Map` from the retrieved `String`
+  .getFloat("price") // Get the `Float` value associated to the `price` key
+  .multiply(1000000) // Use 6 digit precision
+  .round() // Cast to integer
+
+// Retrieves USDT price of CFX from the OkEx API
+const okex = new Witnet.Source("https://www.okex.com/api/index/v3/CFX-USD/constituents")
+  .parseJSONMap() // Parse a `Map` from the retrieved `String`
+  .getMap("data") // Access to the `Map` object at `data` key
+  .getFloat("last") // Get the `Float` value associated to the `last` key
+  .multiply(1000000) // Use 6 digit precision
+  .round() // Cast to integer
+
+// Retrieves USDT price of CFX from the Gate.io API
+const gateio = new Witnet.Source("https://data.gateapi.io/api2/1/ticker/cfx_usdt")
+  .parseJSONMap() // Parse a `Map` from the retrieved `String`
+  .getFloat("last") // Get the `Float` value associated to the `last` key
+  .multiply(1000000) // Use 6 digit precision
+  .round() // Cast to integer
+
+// Retrieves USDT price of CFX from the MEXC API
+const mexc = new Witnet.Source("https://www.mxc.com/open/api/v2/market/ticker?symbol=CFX_USDT")
+  .parseJSONMap() // Parse a `Map` from the retrieved `String`
+  .getArray("data") // Access to the `Array` object at `data` key
+  .getMap(0) // Access to the `Map` object at index 0
+  .getString("last") // Get the `String` value associated to the `last` key
+  .asFloat() // Parse `String` as `Float`
+  .multiply(1000000) // Use 6 digit precision
+  .round() // Cast to integer
+
+// Retrieves USDT price of CFX from the BKEX API
+const bkex = new Witnet.Source("https://api.bkex.cc/v2/q/ticker/price?symbol=CFX_USDT")
+  .parseJSONMap() // Parse a `Map` from the retrieved `String`
+  .getArray("data") // Access to the `Array` object at `data` key
+  .getMap(0) // Access to the `Map` object at index 0
+  .getFloat("price") // Get the `String` value associated to the `price` key
+  .multiply(1000000) // Use 6 digit precision
+  .round() // Cast to integer
+
+// Filters out any value that is more than 1.5 times the standard
+// deviationaway from the average, then computes the average mean of the
+// values that pass the filter.
+const aggregator = new Witnet.Aggregator({
+  filters: [
+    [Witnet.Types.FILTERS.deviationStandard, 1.5],
+  ],
+  reducer: Witnet.Types.REDUCERS.averageMean,
+})
+
+// Filters out any value that is more than 1.5 times the standard
+// deviationaway from the average, then computes the average mean of the
+// values that pass the filter.
+const tally = new Witnet.Tally({
+  filters: [
+    [Witnet.Types.FILTERS.deviationStandard, 1.5],
+  ],
+  reducer: Witnet.Types.REDUCERS.averageMean,
+})
+
+// This is the Witnet.Request object that needs to be exported
+const request = new Witnet.Request()
+  .addSource(binance)
+  .addSource(okex)
+  .addSource(gateio)
+  .addSource(mexc)
+  .addSource(bkex)
+  .setAggregator(aggregator) // Set the aggregator function
+  .setTally(tally) // Set the tally function
+  .setQuorum(100, 70) // Set witness count
+  .setFees(10, 1) // Set economic incentives
+
+// Do not forget to export the request object
+export { request as default }


### PR DESCRIPTION
This is an example of a CFX/USDT price feed using 6 decimal digits and 5 different APIs.