### PR TITLE
fix(scripts): use default if `WITNET_EVM_REALM` is undefined

### DIFF
--- a/scripts/avail-networks.js
+++ b/scripts/avail-networks.js
@@ -1,9 +1,9 @@
 require("dotenv").config()
 
-const realm = process.env.WITNET_EVM_REALM.toLowerCase() || "default"
+const realm = process.env.WITNET_EVM_REALM || "default"
 const settings = require("../migrations/erc2362.settings")
 
-const networks = Object.keys(settings.networks[realm])
+const networks = Object.keys(settings.networks[realm.toLowerCase()])
 console.log(`\nAvailable networks within realm ${realm.toUpperCase()}:\n`)
 networks.forEach(network => console.log(`  ${network}`))
 console.log()


### PR DESCRIPTION
If the environment variable WITNET_EVM_REALM is not defined, then the `avail:networks` scripts fails because it tries to call `toLowerCase()` of an undefined variable.